### PR TITLE
Add missing codes

### DIFF
--- a/code_mapper.go
+++ b/code_mapper.go
@@ -30,6 +30,7 @@ var stateCodeToFIPSCodeMap = map[string]string{
 	"CO": "08",
 	"CT": "09",
 	"DE": "10",
+	"DC": "11",
 	"FL": "12",
 	"GA": "13",
 	"HI": "15",
@@ -73,9 +74,13 @@ var stateCodeToFIPSCodeMap = map[string]string{
 	"WI": "55",
 	"WY": "56",
 	"AS": "60",
+	"FM": "64",
 	"GU": "66",
+	"MH": "68",
 	"MP": "69",
+	"PW": "70",
 	"PR": "72",
+	"UM": "74",
 	"VI": "78",
 }
 
@@ -96,6 +101,7 @@ var fipsCodeToStateCodeMap = map[string]string{
 	"08": "CO",
 	"09": "CT",
 	"10": "DE",
+	"11": "DC",
 	"12": "FL",
 	"13": "GA",
 	"15": "HI",
@@ -139,9 +145,13 @@ var fipsCodeToStateCodeMap = map[string]string{
 	"55": "WI",
 	"56": "WY",
 	"60": "AS",
+	"64": "FM",
 	"66": "GU",
+	"68": "MH",
 	"69": "MP",
+	"70": "PW",
 	"72": "PR",
+	"74": "UM",
 	"78": "VI",
 }
 

--- a/code_mapper_test.go
+++ b/code_mapper_test.go
@@ -19,9 +19,10 @@ package fips_state_codes_test
 
 import (
 	"fmt"
+	"testing"
+
 	fips_state_codes "github.com/moov-io/fips-state-codes"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestFIPSCodeFromStateCode(t *testing.T) {
@@ -34,8 +35,7 @@ func TestFIPSCodeFromStateCode_ErrorsOnUnknownStateCode(t *testing.T) {
 	inputCode := "ZZ"
 	result, err := fips_state_codes.FIPSCodeFromStateCode(inputCode)
 	require.Equal(t, "", result)
-	require.Error(t, err)
-	require.Equal(t, fmt.Sprintf("unknown state code: %s", inputCode), err.Error())
+	require.EqualError(t, err, fmt.Sprintf("unknown state code: %s", inputCode))
 }
 
 func TestStateCodeFromFIPSCode(t *testing.T) {
@@ -48,6 +48,5 @@ func TestStateCodeFromFIPSCode_ErrorsOnUnknownStateCode(t *testing.T) {
 	inputCode := "ZZ"
 	result, err := fips_state_codes.StateCodeFromFIPSCode(inputCode)
 	require.Equal(t, "", result)
-	require.Error(t, err)
-	require.Equal(t, fmt.Sprintf("unknown fips code: %s", inputCode), err.Error())
+	require.EqualError(t, err, fmt.Sprintf("unknown fips code: %s", inputCode))
 }


### PR DESCRIPTION
- add missing fips codes for DC and other outlying territories
  - Sources:
    - https://www.census.gov/library/reference/code-lists/ansi/ansi-codes-for-states.html
    - https://www.bls.gov/respondents/mwr/electronic-data-interchange/appendix-d-usps-state-abbreviations-and-fips-codes.htm 
- clean up testing error asserts